### PR TITLE
Get rid of `boost/filesystem/fstream.hpp`

### DIFF
--- a/src/apps/cc/test/integration.cpp
+++ b/src/apps/cc/test/integration.cpp
@@ -251,10 +251,9 @@ BOOST_DATA_TEST_CASE(
   TempDirFixture fx{CLIParserFixture::keepTempdir};
   // prepare empty config file
   fs::path pathConfig{fx.pathTempdir / "scdetect-cc.cfg"};
-  try {
-    fs::ofstream{pathConfig};
-  } catch (fs::filesystem_error &e) {
-    BOOST_FAIL("Failed to prepare dummy config file: " << e.what());
+  std::ofstream ofs{pathConfig.string()};
+  if (!ofs) {
+    BOOST_FAIL("Failed to prepare dummy config file: " << pathConfig);
   }
 
   fs::path pathEpResultSCML{fx.pathTempdir / "ep.scml"};

--- a/src/apps/cc/test/reducing_amplitude_processor.cpp
+++ b/src/apps/cc/test/reducing_amplitude_processor.cpp
@@ -12,7 +12,6 @@
 #include <seiscomp/unittest/unittests.h>
 
 #include <algorithm>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/optional/optional.hpp>


### PR DESCRIPTION
Use `std::ofstream`, instead. Note that the `boost/filesystem/fstream.hpp` is not included automatically (`boost::filesystem>=1.79`).

Closes #112.