### PR TITLE
Fix phase association

### DIFF
--- a/src/apps/cc/config/detector.cpp
+++ b/src/apps/cc/config/detector.cpp
@@ -189,12 +189,12 @@ TemplateConfig::TemplateConfig(const boost::property_tree::ptree &pt,
       wfStreamId = streamConfig.wfStreamId;
     } catch (boost::property_tree::ptree_error &e) {
       throw config::ParserException{
-          std::string{"Exception while parsing stream config: "} + e.what()};
+          std::string{"exception while parsing stream config: "} + e.what()};
     }
 
     if (!_streamConfigs[wfStreamId].isValid()) {
       throw config::ParserException{
-          std::string{"Exception while parsing streamConfig: Invalid "
+          std::string{"exception while parsing streamConfig: invalid "
                       "stream configuration for stream: "} +
           wfStreamId};
     }
@@ -212,7 +212,7 @@ TemplateConfig::TemplateConfig(const boost::property_tree::ptree &pt,
 
   if (!_detectorConfig.isValid(maxArrivals)) {
     throw config::ParserException{
-        "Invalid template specific detector configuration"};
+        "invalid template specific detector configuration"};
   }
 }
 

--- a/src/apps/cc/config/validators.cpp
+++ b/src/apps/cc/config/validators.cpp
@@ -22,7 +22,7 @@ bool validateMinArrivals(int n, int numStreamConfigs) {
     return true;
   }
 
-  return numStreamConfigs > 0 ? n >= 1 : n >= 1 && n <= numStreamConfigs;
+  return numStreamConfigs > 0 ? n >= 1 && n <= numStreamConfigs : n >= 1;
 }
 
 bool validateSamplingFrequency(double samplingFrequency) {

--- a/src/apps/cc/detector/linker/pot.cpp
+++ b/src/apps/cc/detector/linker/pot.cpp
@@ -146,19 +146,18 @@ bool POT::validateEnabledOffsets(const std::string &processorId,
     return false;
   }
 
+  std::vector<bool> commonMask(size());
   // create mask with common enabled processors
-  std::vector<bool> common_mask(size(), false);
   size_type i{0};
-  for (const auto &p : _processorIdxMap) {
-    if (p.second.enabled && otherMask[i]) {
-      common_mask[i++] = true;
-    }
+  for (const auto &idxPair : _processorIdxMap) {
+    commonMask[i] = idxPair.second.enabled && otherMask[i];
+    ++i;
   }
 
   const auto &offsets{_offsets[std::distance(_processorIdxMap.begin(), it)]};
 
   for (size_type i{0}; i < size(); ++i) {
-    if (common_mask[i] && validEntry(otherOffsets[i]) &&
+    if (commonMask[i] && validEntry(otherOffsets[i]) &&
         validEntry(offsets[i]) &&
         util::greaterThan(std::abs(offsets[i] - otherOffsets[i]),
                           static_cast<double>(thres), tolerance)) {


### PR DESCRIPTION
**Bugfixes**:

- Fix phase association. Actually, this is a regression introduced with a1d8ce843ac81a09b82cc4930fc60a7ca639a80f.
- Fix default `minimumArrivals` module configuration parameter validation.

Closes #125.