### PR TITLE
Flawless git clone sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Get a copy of
 [SeisComP](https://github.com/SeisComP):
 
 ```bash
-TAG='5.3.0'
-# get a copy of SeisComP (follow the official documentation)
+# Select a tag for an apropriate SeisComP release (https://github.com/SeisComP/seiscomp/releases)
+TAG='X.Y.Z'
+
+# Get a copy of SeisComP (follow the official documentation https://www.seiscomp.de/doc/base/build.html?highlight=compile)
 git clone --branch $TAG https://github.com/SeisComP/seiscomp.git 
 git clone --branch $TAG https://github.com/SeisComP/common.git seiscomp/src/base/common
 git clone --branch $TAG https://github.com/SeisComP/main.git seiscomp/src/base/main

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ Get a copy of
 [SeisComP](https://github.com/SeisComP):
 
 ```bash
+TAG='5.3.0'
 # get a copy of SeisComP (follow the official documentation)
-git clone https://github.com/SeisComP/seiscomp.git && cd seiscomp/src/base
-git clone https://github.com/SeisComP/common.git
-git clone https://github.com/SeisComP/main.git
+git clone --branch $TAG https://github.com/SeisComP/seiscomp.git 
+git clone --branch $TAG https://github.com/SeisComP/common.git seiscomp/src/base/common
+git clone --branch $TAG https://github.com/SeisComP/main.git seiscomp/src/base/main
 
 # [... etc ...]
 
@@ -44,7 +45,7 @@ git clone https://github.com/SeisComP/main.git
 Next, clone SCDetect:
 
 ```bash
-cd seiscomp/src/extras && git clone https://github.com/swiss-seismological-service/scdetect.git
+git clone https://github.com/swiss-seismological-service/scdetect.git seiscomp/src/extras/scdetect
 ```
 
 ### Dependencies


### PR DESCRIPTION
- clone in target dirs (all `git clone` commands now run with a simple copy and paste, `cd ../../` was missing before in 2nd block, and it was too many `cd` anyway :)
- clone a tagged SeisComP release (I also suggest adding a note on compatible SeisComP tags).